### PR TITLE
Add language block support to pre tags

### DIFF
--- a/md2htmlV2_test.go
+++ b/md2htmlV2_test.go
@@ -22,15 +22,24 @@ var basicMDv2 = []struct {
 		in:  "||hello||",
 		out: "<span class=\"tg-spoiler\">hello</span>",
 	}, {
-		in:  "```hello```",
-		out: "<pre>hello</pre>",
+		in:  "```content```",
+		out: "<pre>content</pre>",
+	}, {
+		in:  "```code\ncontent```",
+		out: "<pre><code class=\"language-code\">\ncontent</code></pre>",
+	}, {
+		in:  "```spaced words\ncontent```",
+		out: "<pre><code class=\"language-spaced words\">\ncontent</code></pre>",
+	}, {
+		in:  "```quoted\"words\ncontent```",
+		out: "<pre><code class=\"language-quoted&#34;words\">\ncontent</code></pre>",
+	}, {
 		// NOTE: Decide on whether this is just a sad casualty of markdown parsing, or if:
 		//  The closing tag should be the last viable part, if in a sequence. (eg 3x'_', last two are underline closes)
 		//  This means that all other nested items of that tag should be escaped, to avoid:
 		//  __underline  __double underline____, which is impossible. The HTML for this should be
 		//  <u>underline __double underline(__)</u>(__) where () are up to opinion.
 		//  Following my opinion, it should be the first.
-	}, {
 		in:  "___italic underline___",
 		out: "<u><i>italic underline</i></u>",
 	}, {

--- a/reverseV2.go
+++ b/reverseV2.go
@@ -4,20 +4,23 @@ import (
 	"errors"
 	"fmt"
 	"html"
+	"regexp"
 	"strings"
 )
 
 var ErrNoButtonContent = errors.New("no button contents")
 
+var languageCodeblock = regexp.MustCompile(`^(?s)<code class="language-(.*?)">(.*)</code>$`)
+
 func ReverseV2(in string, bs []ButtonV2) (string, error) {
 	return defaultConverterV2.Reverse(in, bs)
 }
 
-func (cv *ConverterV2) Reverse(in string, bs []ButtonV2) (string, error) {
+func (cv ConverterV2) Reverse(in string, bs []ButtonV2) (string, error) {
 	return cv.reverse([]rune(in), bs)
 }
 
-func (cv *ConverterV2) reverse(in []rune, buttons []ButtonV2) (string, error) {
+func (cv ConverterV2) reverse(in []rune, buttons []ButtonV2) (string, error) {
 	prev := 0
 	out := strings.Builder{}
 	for i := 0; i < len(in); i++ {
@@ -63,7 +66,16 @@ func (cv *ConverterV2) reverse(in []rune, buttons []ButtonV2) (string, error) {
 				out.WriteString("`" + html.UnescapeString(string(in[closeTag+1:closingOpen])) + "`")
 			case "pre":
 				// code and pre don't look at nested values, because they're not parsed
-				out.WriteString("```" + html.UnescapeString(string(in[closeTag+1:closingOpen])) + "```")
+				content := html.UnescapeString(string(in[closeTag+1 : closingOpen]))
+				m := languageCodeblock.FindStringSubmatch(content)
+				if len(m) > 0 {
+					// This <pre> block contains a <code class...> block; handle the language.
+					lang, code := m[1], m[2]
+					out.WriteString("```" + lang + code + "```")
+				} else {
+					// This is a regular boring pre block
+					out.WriteString("```" + content + "```")
+				}
 			case "span":
 				// NOTE: All span tags are currently spoiler tags. This may change in the future.
 				if len(tagFields) < 2 {

--- a/stripV2.go
+++ b/stripV2.go
@@ -9,7 +9,7 @@ func StripMDV2(s string) string {
 	return defaultConverterV2.StripMDV2(s)
 }
 
-func (cv *ConverterV2) StripMDV2(s string) string {
+func (cv ConverterV2) StripMDV2(s string) string {
 	text, _ := cv.MD2HTMLButtons(s)
 	return cv.stripHTML([]rune(text))
 }
@@ -18,11 +18,11 @@ func StripHTMLV2(s string) string {
 	return defaultConverterV2.stripHTML([]rune(s))
 }
 
-func (cv *ConverterV2) StripHTMLV2(s string) string {
+func (cv ConverterV2) StripHTMLV2(s string) string {
 	return cv.stripHTML([]rune(s))
 }
 
-func (cv *ConverterV2) stripHTML(in []rune) string {
+func (cv ConverterV2) stripHTML(in []rune) string {
 	out := strings.Builder{}
 	for i := 0; i < len(in); i++ {
 		switch in[i] {


### PR DESCRIPTION
This adds support for language blocks such as:

    ```lang
    content
    ```

This gets rendered as: `<pre><code class="language-lang">content</code></pre>`