### PR TITLE
Improve handling of hyperlinks/buttons/premium emoji

### DIFF
--- a/common.go
+++ b/common.go
@@ -47,7 +47,6 @@ func contains(r rune, rr []rune) bool {
 	return false
 }
 
-// todo: remove regexp dep
 var link = regexp.MustCompile(`a href="(.*)"`)
 var customEmoji = regexp.MustCompile(`tg-emoji emoji-id="(.*)"`)
 

--- a/common.go
+++ b/common.go
@@ -6,11 +6,35 @@ import (
 )
 
 func validStart(pos int, input []rune) bool {
-	return (pos == 0 || !(unicode.IsLetter(input[pos-1]) || unicode.IsDigit(input[pos-1]))) && !(pos == len(input)-1 || unicode.IsSpace(input[pos+1]))
+	// Last char is not a valid start char.
+	// If the next char is a space, it isn't a valid start either.
+	if pos == len(input)-1 || unicode.IsSpace(input[pos+1]) {
+		return false
+	}
+
+	// First char is always a valid start.
+	if pos == 0 {
+		return true
+	}
+
+	// If the previous char is alphanumeric, it is an invalid start char.
+	return !(unicode.IsLetter(input[pos-1]) || unicode.IsDigit(input[pos-1]))
 }
 
 func validEnd(pos int, input []rune) bool {
-	return !(pos == 0 || unicode.IsSpace(input[pos-1])) && (pos == len(input)-1 || !(unicode.IsLetter(input[pos+1]) || unicode.IsDigit(input[pos+1])))
+	// First char is not a valid end char.
+	// If the end char has a space before it, its not valid either.
+	if pos == 0 || unicode.IsSpace(input[pos-1]) {
+		return false
+	}
+
+	// Last char is always a valid end char;
+	if pos == len(input)-1 {
+		return true
+	}
+
+	// If the next char is alphanumeric, it is an invalid end char.
+	return !(unicode.IsLetter(input[pos+1]) || unicode.IsDigit(input[pos+1]))
 }
 
 func contains(r rune, rr []rune) bool {

--- a/commonV2.go
+++ b/commonV2.go
@@ -26,11 +26,11 @@ func findLinkMidSectionIdx(in []rune, emoji bool) int {
 }
 
 // finds the closing ')' section of in a link markdown
-func findLinkEndSectionIdx(in []rune, emoji bool) int {
+func findLinkEndSectionIdx(in []rune) int {
 	var linkEnd int
 	var offset int
 	for offset < len(in) {
-		idx := getValidLinkEnd(in[offset:], emoji)
+		idx := getLinkEnd(in[offset:])
 		if idx < 0 {
 			return -1
 		}
@@ -44,13 +44,13 @@ func findLinkEndSectionIdx(in []rune, emoji bool) int {
 }
 
 // finds the middle and closing sections of in a link markdown
-func findLinkSectionsIdx(in []rune, emoji bool) (int, int) {
-	textEnd := findLinkMidSectionIdx(in, emoji)
+func findLinkSectionsIdx(in []rune, isEmojiLink bool) (int, int) {
+	textEnd := findLinkMidSectionIdx(in, isEmojiLink)
 	if textEnd < 0 {
 		return -1, -1
 	}
 
-	linkEnd := findLinkEndSectionIdx(in[textEnd:], emoji)
+	linkEnd := findLinkEndSectionIdx(in[textEnd:])
 	if linkEnd < 0 {
 		return -1, -1
 	}
@@ -60,7 +60,7 @@ func findLinkSectionsIdx(in []rune, emoji bool) (int, int) {
 	// Now, we iterate over the text in between the mid and end sections to see if any other mid sections exist.
 	// If yes, we choose those instead - it would be invalid in a URL anyway.
 	for textEnd < offsetLinkEnd {
-		newTextEnd := findLinkMidSectionIdx(in[textEnd+1:offsetLinkEnd], emoji)
+		newTextEnd := findLinkMidSectionIdx(in[textEnd+1:offsetLinkEnd], isEmojiLink)
 		if newTextEnd == -1 {
 			break
 		}
@@ -105,7 +105,7 @@ func getValidEnd(in []rune, s string) int {
 	return -1
 }
 
-func getValidLinkEnd(in []rune, musBeValid bool) int {
+func getLinkEnd(in []rune) int {
 	offset := 0
 	for offset < len(in) {
 		idx := stringIndex(in[offset:], ")")
@@ -114,8 +114,8 @@ func getValidLinkEnd(in []rune, musBeValid bool) int {
 		}
 
 		end := offset + idx
-		// validEnd check has double logic to account for multi char strings
-		if (validEnd(end, in) || musBeValid) && !IsEscaped(in, end) {
+		// we don't check validEnd, since links can be inlined
+		if !IsEscaped(in, end) {
 			return end
 		}
 		offset = end + 1

--- a/commonV2.go
+++ b/commonV2.go
@@ -1,36 +1,54 @@
 package tg_md2html
 
-func findLinkSectionsIdx(in []rune) (int, int) {
-	var textEnd, linkEnd int
+// finds the middle '](' section of in a link markdown
+func findLinkMidSectionIdx(in []rune) int {
+	var textEnd int
 	var offset int
 	for offset < len(in) {
 		idx := stringIndex(in[offset:], "](")
 		if idx < 0 {
-			return -1, -1
+			return -1
 		}
 		textEnd = offset + idx
 		if !IsEscaped(in, textEnd) {
-			break
+			return textEnd
 		}
 		offset = textEnd + 1
 	}
-	if offset >= len(in) {
-		return -1, -1
-	}
+	return -1
+}
 
-	offset = textEnd
+// finds the closing ')' section of in a link markdown
+func findLinkEndSectionIdx(in []rune) int {
+	var linkEnd int
+	var offset int
 	for offset < len(in) {
 		idx := getValidLinkEnd(in[offset:])
 		if idx < 0 {
-			return -1, -1
+			return -1
 		}
 		linkEnd = offset + idx
 		if !IsEscaped(in, linkEnd) {
-			return textEnd, linkEnd
+			return linkEnd
 		}
 		offset = linkEnd + 1
 	}
-	return -1, -1
+	return -1
+}
+
+// finds the middle and closing sections of in a link markdown
+func findLinkSectionsIdx(in []rune) (int, int) {
+	textEnd := findLinkMidSectionIdx(in)
+	if textEnd < 0 {
+		return -1, -1
+	}
+
+	linkEnd := findLinkEndSectionIdx(in[textEnd:])
+	if linkEnd < 0 {
+		return -1, -1
+	}
+
+	return textEnd, linkEnd + textEnd
 }
 
 func getLinkContents(in []rune) (bool, []rune, string, int) {

--- a/commonV2.go
+++ b/commonV2.go
@@ -3,7 +3,6 @@ package tg_md2html
 func findLinkSectionsIdx(in []rune) (int, int) {
 	var textEnd, linkEnd int
 	var offset int
-	foundTextEnd := false
 	for offset < len(in) {
 		idx := stringIndex(in[offset:], "](")
 		if idx < 0 {
@@ -11,12 +10,11 @@ func findLinkSectionsIdx(in []rune) (int, int) {
 		}
 		textEnd = offset + idx
 		if !IsEscaped(in, textEnd) {
-			foundTextEnd = true
 			break
 		}
 		offset = textEnd + 1
 	}
-	if !foundTextEnd {
+	if offset >= len(in) {
 		return -1, -1
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,11 @@
 module github.com/PaulSonOfLars/gotg_md2html
 
-go 1.13
+go 1.19
 
-require github.com/stretchr/testify v1.4.0
+require github.com/stretchr/testify v1.8.4
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,10 @@
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
-github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
-github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
-gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/md2htmlV2.go
+++ b/md2htmlV2.go
@@ -73,11 +73,16 @@ var AllMarkdownV2Chars = func() []rune {
 
 func (cv ConverterV2) MD2HTML(in string) string {
 	text, _ := cv.md2html([]rune(html.EscapeString(in)), false)
-	return text
+	return strings.TrimSpace(text)
 }
 
 func (cv ConverterV2) MD2HTMLButtons(in string) (string, []ButtonV2) {
-	return cv.md2html([]rune(html.EscapeString(in)), true)
+	text, btns := cv.md2html([]rune(html.EscapeString(in)), true)
+	return strings.TrimSpace(text), btns
+}
+
+var skipStarts = map[rune]bool{
+	'!': true, // premium emoji
 }
 
 // TODO: add support for a map-like check of which items cannot be included.
@@ -94,7 +99,7 @@ func (cv ConverterV2) md2html(in []rune, enableButtons bool) (string, []ButtonV2
 			continue
 		}
 
-		if !validStart(i, in) {
+		if !validStart(i, in) && !skipStarts[c] {
 			if c == '\\' && i+1 < len(in) {
 				if _, ok := chars[string(in[i+1])]; ok {
 					out.WriteRune(in[i+1])
@@ -153,12 +158,14 @@ func (cv ConverterV2) md2html(in []rune, enableButtons bool) (string, []ButtonV2
 			followT, followB := cv.md2html(in[nEnd+len(item):], enableButtons)
 
 			return out.String() + "<" + chars[item] + ">" + nestedT + "</" + closeSpans(chars[item]) + ">" + followT, append(nestedB, followB...)
+
 		case '!':
-			if len(in) < i+1 || in[i+1] != '[' {
+			if len(in) <= i+1 || in[i+1] != '[' {
+				out.WriteRune(c)
 				continue
 			}
 
-			ok, text, content, newEnd := getLinkContents(in[i+1:])
+			ok, text, content, newEnd := getLinkContents(in[i+1:], true)
 			if !ok {
 				out.WriteRune(c)
 				continue
@@ -167,12 +174,12 @@ func (cv ConverterV2) md2html(in []rune, enableButtons bool) (string, []ButtonV2
 
 			content = strings.TrimPrefix(content, "tg://emoji?id=")
 
+			nestedT, nestedB := cv.md2html(text, enableButtons)
 			followT, followB := cv.md2html(in[end:], enableButtons)
-			nestedT, nestedB := cv.md2html(text, true)
 			return out.String() + `<tg-emoji emoji-id="` + content + `">` + nestedT + "</tg-emoji>" + followT, append(nestedB, followB...)
 
 		case '[':
-			ok, text, content, newEnd := getLinkContents(in[i:])
+			ok, text, content, newEnd := getLinkContents(in[i:], false)
 			if !ok {
 				out.WriteRune(c)
 				continue
@@ -182,7 +189,7 @@ func (cv ConverterV2) md2html(in []rune, enableButtons bool) (string, []ButtonV2
 			followT, followB := cv.md2html(in[end:], enableButtons)
 
 			if enableButtons {
-				for name, prefix := range cv.Prefixes {
+				for buttonType, prefix := range cv.Prefixes {
 					if !strings.HasPrefix(content, prefix) {
 						continue
 					}
@@ -192,16 +199,17 @@ func (cv ConverterV2) md2html(in []rune, enableButtons bool) (string, []ButtonV2
 					if sameline {
 						content = strings.TrimSuffix(content, cv.SameLineSuffix)
 					}
+					cleanedName := cv.StripMDV2(string(text))
 					return out.String() + followT, append([]ButtonV2{{
-						Name:     html.UnescapeString(string(text)),
-						Type:     name,
+						Name:     html.UnescapeString(cleanedName),
+						Type:     buttonType,
 						Content:  content,
 						SameLine: sameline,
 					}}, followB...)
 				}
 			}
 
-			nestedT, nestedB := cv.md2html(text, true)
+			nestedT, nestedB := cv.md2html(text, enableButtons)
 			return out.String() + `<a href="` + content + `">` + nestedT + "</a>" + followT, append(nestedB, followB...)
 
 		case ']', '(', ')':

--- a/md2htmlV2.go
+++ b/md2htmlV2.go
@@ -90,6 +90,8 @@ var skipStarts = map[rune]bool{
 //
 //	Eg: `code` cannot be italic/bold/underline/strikethrough
 //	however... this is currently implemented by server side by telegram, so not my problem :runs:
+//
+// (see notes on: https://core.telegram.org/bots/api#markdownv2-style)
 func (cv ConverterV2) md2html(in []rune, enableButtons bool) (string, []ButtonV2) {
 	out := strings.Builder{}
 

--- a/md2htmlV2.go
+++ b/md2htmlV2.go
@@ -83,6 +83,7 @@ func (cv ConverterV2) MD2HTMLButtons(in string) (string, []ButtonV2) {
 
 var skipStarts = map[rune]bool{
 	'!': true, // premium emoji
+	'[': true, // links
 }
 
 // TODO: add support for a map-like check of which items cannot be included.

--- a/md2htmlV2_test.go
+++ b/md2htmlV2_test.go
@@ -137,9 +137,9 @@ func TestMD2HTMLV2Buttons(t *testing.T) {
 			in:  "[hello](buttonurl://test.com\\)\n[hello2](buttonurl:test.com)",
 			out: "",
 			btns: []tg_md2html.ButtonV2{{
-				Name:    "hello",
+				Name:    "hello](buttonurl://test.com\\)\n[hello2",
 				Type:    "url",
-				Content: "test.com\\)\n[hello2](buttonurl:test.com",
+				Content: "test.com",
 			}},
 		}, {
 			in:  "[text](buttontext:This is some basic text)\n[hello2](buttonurl:test.com)",

--- a/md2htmlV2_test.go
+++ b/md2htmlV2_test.go
@@ -43,16 +43,19 @@ var basicMDv2 = []struct {
 		in:  "____double underline____",
 		out: "<u><u>double underline</u></u>",
 	}, {
+		in:  "[hello](test.com)",
+		out: `<a href="test.com">hello</a>`,
+	}, {
+		in:  "inline[url](test.com)test",
+		out: `inline<a href="test.com">url</a>test`,
+	}, {
 		// pre and code dont support nested, so we dont parse the nested data.
 		in:  "````coded code block````",
 		out: "<pre>`coded code block`</pre>",
 	}, { // ensure that premium stickers can get converted
 		in:  `![👍](tg://emoji?id=5368324170671202286)`,
 		out: `<tg-emoji emoji-id="5368324170671202286">👍</tg-emoji>`,
-	}, { // make sure that text finishing with ! doesnt cause an OOB
-		in:  `test !`,
-		out: `test !`,
-	},
+	}, {},
 }
 
 func TestMD2HTMLV2Basic(t *testing.T) {
@@ -91,75 +94,156 @@ func TestNotMD2HTMLV2(t *testing.T) {
 			in:  "__hello__there",
 			out: "__hello__there",
 		}, {
-			in:  "[hello](test.com)",
-			out: `<a href="test.com">hello</a>`,
-		}, {
 			in:  "||bad spoiler",
 			out: "||bad spoiler",
 		}, {
 			in:  "|noop|",
 			out: "|noop|",
+		}, {
+			in:  "no premium ! in text", // confirm that a '!' doesnt break premiums
+			out: "no premium ! in text",
+		}, {
+			in:  "no premium!", // confirm that ending with '!' doesn't break premiums
+			out: "no premium!",
+		}, {
+			in:  `test !`, // Also check ' !'
+			out: `test !`,
+		}, {
+			// Premium Emoji matching should be greedy
+			in:  "Some text ![😎](tg://emoji?id=6026150900848923116)andstuckhere![😎](tg://emoji?id=6026150900848923116), more text",
+			out: "Some text <tg-emoji emoji-id=\"6026150900848923116\">😎</tg-emoji>andstuckhere<tg-emoji emoji-id=\"6026150900848923116\">😎</tg-emoji>, more text",
 		},
 	} {
 		t.Run(x.in, func(t *testing.T) {
-			assert.Equal(t, x.out, tg_md2html.MD2HTMLV2(x.in))
+			txt := tg_md2html.MD2HTMLV2(x.in)
+			assert.Equal(t, x.out, txt)
 		})
 	}
 }
 
-func TestMD2HTMLV2Buttons(t *testing.T) {
-	for _, x := range []struct {
-		in   string
-		out  string
-		btns []tg_md2html.ButtonV2
-	}{
-		{
-			in:  "[hello](buttonurl:test.com)",
-			out: "",
-			btns: []tg_md2html.ButtonV2{{
-				Name:    "hello",
-				Type:    "url",
-				Content: "test.com",
-			}},
+var md2HTMLV2Buttons = []struct {
+	in   string
+	out  string
+	btns []tg_md2html.ButtonV2
+}{
+	{
+		in:  "[hello](buttonurl:test.com)",
+		out: "",
+		btns: []tg_md2html.ButtonV2{{
+			Name:    "hello",
+			Type:    "url",
+			Content: "test.com",
+		}},
+	}, {
+		in:  "Some text, some *bold*, and a button\n[hello](buttonurl://test.com)",
+		out: "Some text, some <b>bold</b>, and a button",
+		btns: []tg_md2html.ButtonV2{{
+			Name:    "hello",
+			Type:    "url",
+			Content: "test.com",
+		}},
+	}, {
+		in:  "Some text, some *bold*, and a button\n[hello](buttontext://some text)",
+		out: "Some text, some <b>bold</b>, and a button",
+		btns: []tg_md2html.ButtonV2{{
+			Name:    "hello",
+			Type:    "text",
+			Content: "some text",
+		}},
+	}, {
+		in:  "Some text, some *bold*, and a button\n[hello](buttontext://some text:same)",
+		out: "Some text, some <b>bold</b>, and a button",
+		btns: []tg_md2html.ButtonV2{{
+			Name:     "hello",
+			Type:     "text",
+			Content:  "some text",
+			SameLine: true,
+		}},
+	}, {
+		in:   "[hello](buttonurl://test.com\\)",
+		out:  "[hello](buttonurl://test.com)",
+		btns: nil,
+	}, {
+		in:  "[hello](buttonurl://test.com\\)\n[hello2](buttonurl:test.com)",
+		out: "",
+		btns: []tg_md2html.ButtonV2{{
+			Name:    "hello](buttonurl://test.com)\n[hello2",
+			Type:    "url",
+			Content: "test.com",
+		}},
+	}, {
+		in:  "[text](buttontext:This is some basic text)\n[hello2](buttonurl:test.com)",
+		out: "",
+		btns: []tg_md2html.ButtonV2{{
+			Name:    "text",
+			Type:    "text",
+			Content: "This is some basic text",
 		}, {
-			in:  "Some text, some *bold*, and a button [hello](buttonurl://test.com)",
-			out: "Some text, some <b>bold</b>, and a button ",
-			btns: []tg_md2html.ButtonV2{{
-				Name:    "hello",
-				Type:    "url",
-				Content: "test.com",
-			}},
-		}, {
-			in:   "[hello](buttonurl://test.com\\)",
-			out:  "[hello](buttonurl://test.com)",
-			btns: nil,
-		}, {
-			in:  "[hello](buttonurl://test.com\\)\n[hello2](buttonurl:test.com)",
-			out: "",
-			btns: []tg_md2html.ButtonV2{{
-				Name:    "hello](buttonurl://test.com\\)\n[hello2",
-				Type:    "url",
-				Content: "test.com",
-			}},
-		}, {
-			in:  "[text](buttontext:This is some basic text)\n[hello2](buttonurl:test.com)",
-			out: "\n",
-			btns: []tg_md2html.ButtonV2{{
-				Name:    "text",
-				Type:    "text",
-				Content: "This is some basic text",
-			}, {
-				Name:    "hello2",
-				Type:    "url",
-				Content: "test.com",
-			}},
+			Name:    "hello2",
+			Type:    "url",
+			Content: "test.com",
+		}},
+	}, {
+		// This is not a valid URL
+		in:   "[text](tg://emoji?id=6026150900848923116)",
+		out:  "[text](tg://emoji?id=6026150900848923116)",
+		btns: nil,
+	}, {
+		in:  "Some text [![😎](tg://emoji?id=6026150900848923116) text](buttonurl://example.com)",
+		out: "Some text",
+		btns: []tg_md2html.ButtonV2{
+			{
+				Name:     "😎 text",
+				Type:     "url",
+				Content:  "example.com",
+				SameLine: false,
+			},
 		},
-	} {
+	}, {
+		in:  "[![🌐](tg://emoji?id=5343789187172670307)Website](buttonurl://example.com)",
+		out: "",
+		btns: []tg_md2html.ButtonV2{
+			{
+				Name:     "🌐Website",
+				Type:     "url",
+				Content:  "example.com",
+				SameLine: false,
+			},
+		},
+	}, {
+		// This one has a space between emoji and website! which causes different output...!
+		in:  "[![🌐](tg://emoji?id=5343789187172670307) Website](buttonurl://example.com)",
+		out: "",
+		btns: []tg_md2html.ButtonV2{
+			{
+				Name:     "🌐 Website",
+				Type:     "url",
+				Content:  "example.com",
+				SameLine: false,
+			},
+		},
+	}, {
+		// Handle the edge case where people are purposefully trying to break buttons
+		in:  "[![🌐](buttonurl://example.com)",
+		out: "",
+		btns: []tg_md2html.ButtonV2{
+			{
+				Name:     "![🌐",
+				Type:     "url",
+				Content:  "example.com",
+				SameLine: false,
+			},
+		},
+	},
+}
+
+func TestMD2HTMLV2Buttons(t *testing.T) {
+	for _, x := range md2HTMLV2Buttons {
+		cv := tg_md2html.NewV2(map[string]string{
+			"url":  "buttonurl:",
+			"text": "buttontext:",
+		})
 		t.Run(x.in, func(t *testing.T) {
-			cv := tg_md2html.NewV2(map[string]string{
-				"url":  "buttonurl:",
-				"text": "buttontext:",
-			})
 			txt, b := cv.MD2HTMLButtons(x.in)
 			assert.Equal(t, x.out, txt)
 			assert.ElementsMatch(t, x.btns, b)

--- a/reverseV2.go
+++ b/reverseV2.go
@@ -13,11 +13,12 @@ func ReverseV2(in string, bs []ButtonV2) (string, error) {
 	return defaultConverterV2.Reverse(in, bs)
 }
 
-func (cv *ConverterV2) Reverse(in string, bs []ButtonV2) (string, error) {
-	return cv.reverse([]rune(in), bs)
+func (cv ConverterV2) Reverse(in string, bs []ButtonV2) (string, error) {
+	text, err := cv.reverse([]rune(in), bs)
+	return strings.TrimSpace(text), err
 }
 
-func (cv *ConverterV2) reverse(in []rune, buttons []ButtonV2) (string, error) {
+func (cv ConverterV2) reverse(in []rune, buttons []ButtonV2) (string, error) {
 	prev := 0
 	out := strings.Builder{}
 	for i := 0; i < len(in); i++ {
@@ -124,7 +125,7 @@ func (cv ConverterV2) ButtonToMarkdown(btn ButtonV2) (string, error) {
 	}
 
 	if prefix, ok := cv.Prefixes[btn.Type]; ok {
-		return "[" + btn.Name + "](" + prefix + "//" + html.UnescapeString(btn.Content) + sameline + ")", nil
+		return "[" + EscapeMarkdownV2([]rune(btn.Name)) + "](" + prefix + "//" + html.UnescapeString(btn.Content) + sameline + ")", nil
 	}
 	return "", ErrNoButtonContent
 }

--- a/stripV2.go
+++ b/stripV2.go
@@ -9,7 +9,7 @@ func StripMDV2(s string) string {
 	return defaultConverterV2.StripMDV2(s)
 }
 
-func (cv *ConverterV2) StripMDV2(s string) string {
+func (cv ConverterV2) StripMDV2(s string) string {
 	text, _ := cv.MD2HTMLButtons(s)
 	return cv.stripHTML([]rune(text))
 }
@@ -18,11 +18,11 @@ func StripHTMLV2(s string) string {
 	return defaultConverterV2.stripHTML([]rune(s))
 }
 
-func (cv *ConverterV2) StripHTMLV2(s string) string {
+func (cv ConverterV2) StripHTMLV2(s string) string {
 	return cv.stripHTML([]rune(s))
 }
 
-func (cv *ConverterV2) stripHTML(in []rune) string {
+func (cv ConverterV2) stripHTML(in []rune) string {
 	out := strings.Builder{}
 	for i := 0; i < len(in); i++ {
 		switch in[i] {


### PR DESCRIPTION
This PR aims to improve the handling of various types of links by:
- Stripping markdown from button names (to remove premium emoji)
- Allowing for hyperlinks/buttons/emoji to be inlined with a word
- Simplifying some syntax issues

This PR also adds more tests, updates the testing lib, and adds more comments